### PR TITLE
Added setting for choosing encoding of mails received by MailAlarmSource

### DIFF
--- a/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/MailConfiguration.cs
+++ b/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/MailConfiguration.cs
@@ -14,6 +14,8 @@
 // along with AlarmWorkflow.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.IO;
+using System.Text;
 using AlarmWorkflow.BackendService.SettingsContracts;
 using AlarmWorkflow.Shared.Core;
 
@@ -42,6 +44,8 @@ namespace AlarmWorkflow.AlarmSource.Mail
         internal bool AnalyseAttachment { get; private set; }
         internal string AttachmentName { get; private set; }
         internal string ParserAlias { get; private set; }
+        internal Encoding Encoding { get; private set; }
+
         #endregion
 
         #region Constructors
@@ -67,6 +71,19 @@ namespace AlarmWorkflow.AlarmSource.Mail
             AnalyseAttachment = _settings.GetSetting("MailAlarmSource", "AnalyseAttachment").GetValue<bool>();
             AttachmentName = _settings.GetSetting("MailAlarmSource", "AttachmentName").GetValue<string>();
             ParserAlias = _settings.GetSetting("MailAlarmSource", "MailParser").GetValue<string>();
+            int codepage = _settings.GetSetting("MailAlarmSource", "CodePage").GetValue<int>();
+            
+            try
+            {
+                if (codepage != 0)
+                {
+                    Encoding = Encoding.GetEncoding(codepage);
+                }
+            }
+            catch (Exception)
+            {
+                Encoding = null;
+            }
         }
 
         #endregion

--- a/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/settings.info.xml
+++ b/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/settings.info.xml
@@ -8,14 +8,14 @@
     <Setting Name="PollInterval" DisplayText="Abfrageintervall" Category="Server" 
              Editor="DurationTypeEditor"
              EditorParameter="Min=500;Max=600000;Scale=Milliseconds" />
-
+    <Setting Name="CodePage" DisplayText="Zeichensatztabelle‎" Description="Gibt die zu verwendende Zeichensatztabelle(Codepage) an. Nähere Informationen entnehmen Sie bitte dem Handbuch." Category="Konto" />
     <Setting Name="UserName" DisplayText="Benutzername" Category="Konto" />
     <Setting Name="Password" DisplayText="Passwort" Category="Konto" />
 
     <Setting Name="MailSubject" DisplayText="Betreff" Category="E-Mail" />
     <Setting Name="MailSender" DisplayText="Absender (Mailadresse)" Category="E-Mail" />
-
     
+
     <Setting Name="MailParser" DisplayText="Parser-Kennung" Category="Parser" Editor="ExportTypeEditor" EditorParameter="AlarmWorkflow.Shared.Extensibility.IParser, AlarmWorkflow.Shared"
                Description="Welcher Parser die Informationen aus der Mail auswertet." />
 

--- a/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/settings.xml
+++ b/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/settings.xml
@@ -7,10 +7,11 @@
   <Setting Name="UserName" Type="System.String" IsNull="True" />
   <Setting Name="Password" Type="System.String" IsNull="True" />
   <Setting Name="SSL" Type="System.Boolean">false</Setting>
+  <Setting Name="CodePage" Type="System.Int32" IsNull="True" />
+  <Setting Name="PollInterval" Type="System.Int32">10000</Setting>
   
   <Setting Name="MailSubject" Type="System.String">AlarmMail</Setting>
   <Setting Name="MailSender" Type="System.String">aa@bb.cc</Setting>
-  <Setting Name="PollInterval" Type="System.Int32">10000</Setting>
 
   <Setting Name="AnalyseAttachment" Type="System.Boolean">false</Setting>
   <Setting Name="AttachmentName" Type="System.String">alarm.txt</Setting>


### PR DESCRIPTION
User can choose the encoding via an setting. This setting requires an codepage-number. This can be found e.g. here: http://msdn.microsoft.com/en-us/library/dd317756(VS.85).aspx
