### PR TITLE
Added setting for choosing encoding of mails received by MailAlarmSource

### DIFF
--- a/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/MailAlarmSource.cs
+++ b/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/MailAlarmSource.cs
@@ -101,42 +101,60 @@ namespace AlarmWorkflow.AlarmSource.Mail
 
         private void CheckImapMail()
         {
-            using (_imapClient = new ImapClient(_configuration.ServerName, _configuration.Port, _configuration.SSL))
+            try
             {
-                _imapClient.Login(_configuration.UserName, _configuration.Password, AuthMethod.Login);
-                try
+                using (_imapClient = new ImapClient(_configuration.ServerName, _configuration.Port, _configuration.SSL, null, _configuration.Encoding))
                 {
-                    IEnumerable<uint> uids = _imapClient.Search(SearchCondition.Unseen());
-                    foreach (MailMessage msg in uids.Select(uid => _imapClient.GetMessage(uid)))
+                    try
                     {
-                        Logger.Instance.LogFormat(LogType.Debug, this, "New mail " + msg.Subject);
-                        MailOperation(msg);
+                        _imapClient.Login(_configuration.UserName, _configuration.Password, AuthMethod.Login);
+                        IEnumerable<uint> uids = _imapClient.Search(SearchCondition.Unseen());
+                        foreach (MailMessage msg in uids.Select(uid => _imapClient.GetMessage(uid)))
+                        {
+                            Logger.Instance.LogFormat(LogType.Debug, this, "New mail " + msg.Subject);
+                            MailOperation(msg);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Instance.LogException(this, ex);
                     }
                 }
-                catch (Exception ex)
-                {
-                    Logger.Instance.LogFormat(LogType.Error, this, ex.ToString());
-                }
-            }
 
+            }
+            catch (Exception ex)
+            {
+                //Sometimes an error occues e.g. if the internet connection was disconected or an timeout occured. 
+                //Instead of "stopping" the complete alarmsource we log it and continue as normal.
+                Logger.Instance.LogException(this, ex);
+            }
         }
 
         private void MailOperation(MailMessage message)
         {
             if (message.Subject.ToLower().Contains(_configuration.MailSubject.ToLower()) &&
-                message.From.Address.ToLower() == _configuration.MailSender.ToLower())
+                message.From.Address.ToLower().Contains(_configuration.MailSender.ToLower()))
             {
+                Logger.Instance.LogFormat(LogType.Debug, this, "Found matching mail.");
                 Operation operation = null;
                 if (_configuration.AnalyseAttachment)
                 {
                     if (message.Attachments.Count > 0)
                     {
-                        if (message.Attachments[0].Name.ToLowerInvariant() == _configuration.AttachmentName.ToLowerInvariant())
+                        if (string.Equals(message.Attachments[0].Name, _configuration.AttachmentName, StringComparison.InvariantCultureIgnoreCase))
                         {
                             Attachment attachment = message.Attachments[0];
                             byte[] buffer = new byte[attachment.ContentStream.Length];
                             attachment.ContentStream.Read(buffer, 0, buffer.Length);
-                            string content = Encoding.UTF8.GetString(buffer);
+                            string content;
+                            if (_configuration.Encoding != null)
+                            {
+                                content = _configuration.Encoding.GetString(buffer);
+                            }
+                            else
+                            {
+                                content = Encoding.ASCII.GetString(buffer);
+                            }
                             string[] lines = content.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
                             operation = _mailParser.Parse(lines);
                         }

--- a/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/MailConfiguration.cs
+++ b/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/MailConfiguration.cs
@@ -14,6 +14,8 @@
 // along with AlarmWorkflow.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.IO;
+using System.Text;
 using AlarmWorkflow.BackendService.SettingsContracts;
 using AlarmWorkflow.Shared.Core;
 
@@ -42,6 +44,8 @@ namespace AlarmWorkflow.AlarmSource.Mail
         internal bool AnalyseAttachment { get; private set; }
         internal string AttachmentName { get; private set; }
         internal string ParserAlias { get; private set; }
+        internal Encoding Encoding { get; private set; }
+
         #endregion
 
         #region Constructors
@@ -67,6 +71,19 @@ namespace AlarmWorkflow.AlarmSource.Mail
             AnalyseAttachment = _settings.GetSetting("MailAlarmSource", "AnalyseAttachment").GetValue<bool>();
             AttachmentName = _settings.GetSetting("MailAlarmSource", "AttachmentName").GetValue<string>();
             ParserAlias = _settings.GetSetting("MailAlarmSource", "MailParser").GetValue<string>();
+            int codepage = _settings.GetSetting("MailAlarmSource", "CodePage").GetValue<int>();
+            
+            try
+            {
+                if (codepage != 0)
+                {
+                    Encoding = Encoding.GetEncoding(codepage);
+                }
+            }
+            catch (Exception)
+            {
+                Encoding = null;
+            }
         }
 
         #endregion

--- a/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/settings.info.xml
+++ b/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/settings.info.xml
@@ -8,7 +8,7 @@
     <Setting Name="PollInterval" DisplayText="Abfrageintervall" Category="Server" 
              Editor="DurationTypeEditor"
              EditorParameter="Min=500;Max=600000;Scale=Milliseconds" />
-
+    <Setting Name="CodePage" DisplayText="Zeichensatztabelle‎" Description="Gibt die zu verwendende Zeichensatztabelle(Codepage) an. Nähere Informationen entnehmen Sie bitte dem Handbuch." Category="Konto" />
     <Setting Name="UserName" DisplayText="Benutzername" Category="Konto" />
     <Setting Name="Password" DisplayText="Passwort" Category="Konto" />
 

--- a/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/settings.xml
+++ b/Shared/AlarmSources/AlarmWorkflow.AlarmSource.Mail/settings.xml
@@ -7,6 +7,7 @@
   <Setting Name="UserName" Type="System.String" IsNull="True" />
   <Setting Name="Password" Type="System.String" IsNull="True" />
   <Setting Name="SSL" Type="System.Boolean">false</Setting>
+  <Setting Name="CodePage" Type="System.Int32" IsNull="True" />
   
   <Setting Name="MailSubject" Type="System.String">AlarmMail</Setting>
   <Setting Name="MailSender" Type="System.String">aa@bb.cc</Setting>


### PR DESCRIPTION
User can choose the encoding via an setting. This setting requires an codepage-number. This can be found e.g. here: http://msdn.microsoft.com/en-us/library/dd317756(VS.85).aspx

S. #79 und #77
