### PR TITLE
Fügt AnalyzedFileNameFormat den Einstellungen hinzu

### DIFF
--- a/AlarmSources/Fax/FaxAlarmSource.cs
+++ b/AlarmSources/Fax/FaxAlarmSource.cs
@@ -41,7 +41,6 @@ namespace AlarmWorkflow.AlarmSource.Fax
         #region Constants
 
         private const int ErrorRetryCount = 10;
-        private const string AnalyzedFileNameFormat = "yyyyMMddHHmmssffff";
         private const string ArchivedFilePathExtension = ".tif";
         private const int MoveFileAttemptDelayMs = 200;
         private const int RoutineIntervalMs = 2000;
@@ -56,6 +55,8 @@ namespace AlarmWorkflow.AlarmSource.Fax
         private DirectoryInfo _faxPath;
         private DirectoryInfo _archivePath;
         private DirectoryInfo _analysisPath;
+
+        private string _analyzedFileNameFormat;
 
         private IOcrSoftware _ocrSoftware;
         private IParser _parser;
@@ -167,7 +168,7 @@ namespace AlarmWorkflow.AlarmSource.Fax
         {
             EnsureDirectoriesExist();
 
-            string analyseFileName = DateTime.Now.ToString(AnalyzedFileNameFormat);
+            string analyseFileName = DateTime.Now.ToString(_analyzedFileNameFormat);
             string archivedFilePath = Path.Combine(_archivePath.FullName, analyseFileName + ArchivedFilePathExtension);
 
             MoveFileTo(file, archivedFilePath);
@@ -282,6 +283,8 @@ namespace AlarmWorkflow.AlarmSource.Fax
             _faxPath = new DirectoryInfo(_configuration.FaxPath);
             _archivePath = new DirectoryInfo(_configuration.ArchivePath);
             _analysisPath = new DirectoryInfo(_configuration.AnalysisPath);
+
+            _analyzedFileNameFormat = _configuration.AnalyzedFileNameFormat;
 
             Logger.Instance.LogFormat(LogType.Trace, this, Properties.Resources.UsingIncomingFaxDirectory, _faxPath.FullName);
             Logger.Instance.LogFormat(LogType.Trace, this, Properties.Resources.UsingAnalyzedFaxDirectory, _analysisPath.FullName);

--- a/AlarmSources/Fax/FaxConfiguration.cs
+++ b/AlarmSources/Fax/FaxConfiguration.cs
@@ -55,6 +55,11 @@ namespace AlarmWorkflow.AlarmSource.Fax
             get { return _settings.GetSetting(FaxSettingKeys.AnalysisPath).GetValue<string>(); }
         }
 
+        internal string AnalyzedFileNameFormat
+        {
+            get { return _settings.GetSetting(FaxSettingKeys.AnalyzedFileNameFormat).GetValue<string>(); }
+        }
+
         internal string OCRSoftwarePath
         {
             get { return _settings.GetSetting(FaxSettingKeys.OcrPath).GetValue<string>(); }
@@ -102,7 +107,8 @@ namespace AlarmWorkflow.AlarmSource.Fax
                 {
                     changedKeys.Add("OCR.Path");
                 }
-                else if ((key.Equals(FaxSettingKeys.FaxPath) || key.Equals(FaxSettingKeys.AnalysisPath) || key.Equals(FaxSettingKeys.ArchivePath)) && !changedKeys.Contains("FaxPaths"))
+                else if ((key.Equals(FaxSettingKeys.FaxPath) || key.Equals(FaxSettingKeys.AnalysisPath) || key.Equals(FaxSettingKeys.ArchivePath) || key.Equals(FaxSettingKeys.AnalyzedFileNameFormat)) 
+                     && !changedKeys.Contains("FaxPaths"))
                 {
                     changedKeys.Add("FaxPaths");
                 }

--- a/AlarmSources/Fax/FaxSettingKeys.cs
+++ b/AlarmSources/Fax/FaxSettingKeys.cs
@@ -24,6 +24,7 @@ namespace AlarmWorkflow.AlarmSource.Fax
         internal static readonly SettingKey FaxPath = SettingKey.Create(Identifier, "FaxPath");
         internal static readonly SettingKey ArchivePath = SettingKey.Create(Identifier, "ArchivePath");
         internal static readonly SettingKey AnalysisPath = SettingKey.Create(Identifier, "AnalysisPath");
+        internal static readonly SettingKey AnalyzedFileNameFormat = SettingKey.Create(Identifier, "AnalyzedFileNameFormat");
         internal static readonly SettingKey AlarmFaxParserAlias = SettingKey.Create(Identifier, "AlarmfaxParser");
         internal static readonly SettingKey OcrPath = SettingKey.Create(Identifier, "OCR.Path");
     }

--- a/AlarmSources/Fax/settings.info.xml
+++ b/AlarmSources/Fax/settings.info.xml
@@ -9,6 +9,9 @@
     <Setting Name="AnalysisPath" DisplayText="Analyse-Verzeichnis" Category="Verzeichnisse" Editor="DirectoryTypeEditor"
              Description="Verzeichnis für analysierte Faxe." IsDynamic="true"/>
 
+    <Setting Name="AnalyzedFileNameFormat" DisplayText="Format der analysierten Datei" Category="Verzeichnisse"
+             Description="Ausgabeformat des Dateinamen, nachdem diese analysiert wurde. Wird mit der aktuellen Zeit geparst." IsDynamic="true" />
+    
     <Setting Name="OCR.Path" DisplayText="Pfad (Verzeichnis)" Category="Tesseract OCR-Software" Editor="DirectoryTypeEditor"
              Description="Wenn leer gelassen, wird das Standardverzeichnis (innerhalb des Programmverzeichnisses) genommen." IsDynamic="true"/>
 

--- a/AlarmSources/Fax/settings.xml
+++ b/AlarmSources/Fax/settings.xml
@@ -3,6 +3,7 @@
   <Setting Name="FaxPath" Type="System.String" IsNull="False">C:\Fax</Setting>
   <Setting Name="ArchivePath" Type="System.String" IsNull="False">C:\Fax\Archive\</Setting>
   <Setting Name="AnalysisPath" Type="System.String" IsNull="False">C:\Fax\Analysis\</Setting>
+  <Setting Name="AnalyzedFileNameFormat" Type="System.String" IsNull="False">yyyyMMddHHmmssffff</Setting>
   <Setting Name="OCR.Path" Type="System.String" IsNull="False"></Setting>
   <Setting Name="AlarmfaxParser" Type="System.String" IsNull="False">NoParser</Setting>
 </SettingsConfiguration>


### PR DESCRIPTION
Fügt eine weitere Einstellung hinzu, mit dem der Ausgabename der archivierten Faxe angepasst werden kann.