### PR TITLE
Benutze optional OFM in OperationPrint

### DIFF
--- a/Jobs/Engine/OperationPrinter/OperationPrintOFMHelper.htm
+++ b/Jobs/Engine/OperationPrinter/OperationPrintOFMHelper.htm
@@ -1,0 +1,32 @@
+﻿<!--
+    DO NOT CHANGE OR EDIT THIS FILE!
+-->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.css" />
+</head>
+<body style="margin: 0px;">
+    <div id="map" style="width:{MapSize.Width}px; height: {MapSize.Height}px"></div>
+
+    <script src="http://cdn.leafletjs.com/leaflet-0.7.5/leaflet.js"></script>
+    <script>
+
+        var location = [{Location.GeoLatitude}, {Location.GeoLongitude}];
+        var map = L.map('map', {
+            zoomControl: false,
+            attributionControl: false
+        }).setView(location, 17);
+
+        L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        }).addTo(map);
+
+		L.tileLayer('http://www.openfiremap.org/hytiles/{z}/{x}/{y}.png').addTo(map);
+
+		L.marker(location).addTo(map);
+
+    </script>
+</body>
+</html>

--- a/Jobs/Engine/OperationPrinter/OperationPrintTemplate.htm
+++ b/Jobs/Engine/OperationPrinter/OperationPrintTemplate.htm
@@ -52,7 +52,7 @@
         </tr>
         <tr>
             <td colspan="2">
-                <img src="{RouteImageFilePath}" alt="" />
+                <img src="{MapImageFilePath}" alt="" />
             </td>
         </tr>
     </table>

--- a/Jobs/Engine/OperationPrinter/OperationPrinter.csproj
+++ b/Jobs/Engine/OperationPrinter/OperationPrinter.csproj
@@ -93,6 +93,9 @@
     <Content Include="OperationPrintTemplate.htm">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="OperationPrintOFMHelper.htm">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Jobs/Engine/OperationPrinter/OperationPrinterJob.cs
+++ b/Jobs/Engine/OperationPrinter/OperationPrinterJob.cs
@@ -110,6 +110,7 @@ namespace AlarmWorkflow.Job.OperationPrinter
 
         private bool GdiPrinterPrintAction(int pageIndex, Graphics graphics, Rectangle marginBounds, Rectangle pageBounds, PageSettings pageSettings, ref object state)
         {
+            bool useOFM = _settings.GetSetting(SettingKeysJob.UseOFM).GetValue<bool>();
             pageSettings.Landscape = false;
 
             Image renderedImage = state as Image;
@@ -130,7 +131,7 @@ namespace AlarmWorkflow.Job.OperationPrinter
                     return false;
                 }
 
-                renderedImage = TemplateRenderer.RenderOperation(GetSourceLocation(), operation, templateFile, renderBounds);
+                renderedImage = TemplateRenderer.RenderOperation(GetSourceLocation(), operation, templateFile, renderBounds, useOFM);
                 state = renderedImage;
             }
 

--- a/Jobs/Engine/OperationPrinter/SettingKeys.cs
+++ b/Jobs/Engine/OperationPrinter/SettingKeys.cs
@@ -21,5 +21,6 @@ namespace AlarmWorkflow.Job.OperationPrinter
     {
         internal static readonly SettingKey TemplateFile = SettingKey.Create("OperationPrinterJob", "TemplateFile");
         internal static readonly SettingKey PrintingQueueNames = SettingKey.Create("OperationPrinterJob", "PrintingQueueNames");
+        internal static readonly SettingKey UseOFM = SettingKey.Create("OperationPrinterJob", "UseOFM");
     }
 }

--- a/Jobs/Engine/OperationPrinter/TemplateObject.cs
+++ b/Jobs/Engine/OperationPrinter/TemplateObject.cs
@@ -29,9 +29,9 @@ namespace AlarmWorkflow.Job.OperationPrinter
         /// </summary>
         public Operation Operation { get; set; }
         /// <summary>
-        /// Gets/sets the full file path of the route image file.
+        /// Gets/sets the full file path of the map image file.
         /// </summary>
-        public string RouteImageFilePath { get; set; }
+        public string MapImageFilePath { get; set; }
 
         #endregion
     }

--- a/Jobs/Engine/OperationPrinter/settings.info.xml
+++ b/Jobs/Engine/OperationPrinter/settings.info.xml
@@ -2,6 +2,8 @@
   <Identifier Name="OperationPrinterJob" DisplayText="Alarmdetails-Druck" Parent="Aufgaben">
     <Setting Name="TemplateFile" DisplayText="Druckvorlagendatei" Category="Vorlage" Editor="FileTypeEditor" EditorParameter="HTML-Dateien (*.htm; *.html)|*.htm;*.html"
              Description="Die Vorlagendatei, die zum Drucken verwendet wird." IsDynamic="true" />
+    <Setting Name="UseOFM" DisplayText="Benutze OpenFireMap" Category="Vorlage"
+             Description="Soll eine Übersichtskarte mit OpenFireMap anstatt einer Anfahrtskarte mit Google Maps verwendet werden?" IsDynamic="true" />
     <Setting Name="PrintingQueueNames" DisplayText="Druckerwege" Category="Druck" Editor="PrintingQueueNamesTypeEditor"
              Description="Die Druckerwege, auf denen gedruckt werden soll." IsDynamic="true" />
   </Identifier>

--- a/Jobs/Engine/OperationPrinter/settings.xml
+++ b/Jobs/Engine/OperationPrinter/settings.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <SettingsConfiguration Version="1" Identifier="OperationPrinterJob">
   <Setting Name="TemplateFile" Type="System.String">OperationPrintTemplate.htm</Setting>
+  <Setting Name="UseOFM" Type="System.Boolean">false</Setting>
   <Setting Name="PrintingQueueNames" Type="System.String" IsNull="True"></Setting>
 </SettingsConfiguration>

--- a/Resources/Documentation/RelNotes/0.9.9.0.txt
+++ b/Resources/Documentation/RelNotes/0.9.9.0.txt
@@ -16,6 +16,7 @@ Generelles
   * ConfEd: Im Adressbuch sind die Einträge nun nach Nachname/Vorname sortiert.
   * Als benutzerdefinierte Objektausdrücke sind nun auch Skripte in JavaScript möglich, siehe Anhang #2.
   * Die Faxauswertung erkennt nun auch PDF-Dateien.
+  * OperationPrinter kann nun optional auch OpenFireMap ausdrucken
 
 Anhänge
 -------


### PR DESCRIPTION
Erstellt die Möglichkeit, eine OpenFireMap des Einsatzortes anstatt der
Anfahrtsbeschreibung mit Google Maps zu drucken (siehe http://www.openfiresource.de/bugs/view.php?id=155).

Der ObjectFormatter konnte leider nicht zum parsen der HTML-Seite benutzt werden (Fehler aufgrund {x} in JavaScript). 

Möglichkeiten für die Zukunft:
- OFM nur bei bestimmten Stichwörter
- OFM und GoogleMaps gleichzeitig
