### PR TITLE
Geocoding

### DIFF
--- a/Jobs/Engine/Geocoding/Geocoding.cs
+++ b/Jobs/Engine/Geocoding/Geocoding.cs
@@ -73,8 +73,8 @@ namespace AlarmWorkflow.Job.Geocoding
                 if (geocoderLocation != null)
                 {
                     //The most of the widgets and so need the "english-format" (point instead of comma)!
-                    operation.Einsatzort.GeoLongitude = geocoderLocation.Longitude.ToString().Replace(',', '.');
-                    operation.Einsatzort.GeoLatitude = geocoderLocation.Latitude.ToString().Replace(',', '.');
+                    operation.Einsatzort.GeoLongitude = geocoderLocation.Longitude;
+                    operation.Einsatzort.GeoLatitude = geocoderLocation.Latitude;
                 }
                 else
                 {

--- a/Resources/Documentation/RelNotes/0.9.9.0.txt
+++ b/Resources/Documentation/RelNotes/0.9.9.0.txt
@@ -17,6 +17,7 @@ Generelles
   * Als benutzerdefinierte Objektausdrücke sind nun auch Skripte in JavaScript möglich, siehe Anhang #2.
   * Die Faxauswertung erkennt nun auch PDF-Dateien.
   * DispatchTool unterstützt nun das Quittieren empfangener Alarme.
+  * Koordinaten werden intern mit einem besser geeigneten Datentyp verarbeitet
 
 Mail Alarmquelle:
   * Verwendet neue Library MailKit

--- a/Shared/Shared/Core/PropertyLocation.cs
+++ b/Shared/Shared/Core/PropertyLocation.cs
@@ -25,6 +25,12 @@ namespace AlarmWorkflow.Shared.Core
     [Serializable()]
     public sealed class PropertyLocation : IEquatable<PropertyLocation>
     {
+        #region Fields
+
+        private NumberFormatInfo _nfi = new NumberFormatInfo { NumberDecimalSeparator = "." };
+
+        #endregion
+
         #region Properties
 
         /// <summary>
@@ -54,11 +60,25 @@ namespace AlarmWorkflow.Shared.Core
         /// <summary>
         /// Gets/sets the latitude of the location (if provided by alarmsource).
         /// </summary>
-        public string GeoLatitude { get; set; }
+        public double? GeoLatitude { get; set; }
         /// <summary>
         /// Gets/sets the longitude of the location (if provided by alarmsource).
         /// </summary>
-        public string GeoLongitude { get; set; }
+        public double? GeoLongitude { get; set; }
+        /// <summary>
+        /// Gets the latitude of the location in a string with a "."
+        /// </summary>
+        public string GeoLatitudeString
+        {
+            get { return GeoLatitude.HasValue ? GeoLatitude.Value.ToString(_nfi) : string.Empty; }
+        }
+        /// <summary>
+        ///  Gets the longitude of the location in a string with a "."
+        /// </summary>
+        public string GeoLongitudeString
+        {
+            get { return GeoLongitude.HasValue ? GeoLongitude.Value.ToString(_nfi) : string.Empty; }
+        }
         /// <summary>
         /// Gets/sets the name of the property (company, site, house etc.).
         /// </summary>
@@ -69,7 +89,10 @@ namespace AlarmWorkflow.Shared.Core
         /// </summary>
         public string GeoLatLng
         {
-            get { return string.Format(CultureInfo.InvariantCulture, "{0};{1}", GeoLatitude, GeoLongitude); }
+            get
+            {
+                return HasGeoCoordinates ? string.Format(CultureInfo.InvariantCulture, "{0};{1}", GeoLatitude.Value, GeoLongitude.Value) : null;
+            }
             set
             {
                 string[] latlng = new string[2];
@@ -79,8 +102,8 @@ namespace AlarmWorkflow.Shared.Core
                     latlng = value.Split(';');
                 }
 
-                GeoLatitude = latlng[0];
-                GeoLongitude = latlng[1];
+                GeoLatitude = Convert.ToDouble(latlng[0], _nfi);
+                GeoLongitude = Convert.ToDouble(latlng[1], _nfi);
             }
         }
 
@@ -102,7 +125,7 @@ namespace AlarmWorkflow.Shared.Core
         /// </summary>
         public bool HasGeoCoordinates
         {
-            get { return !string.IsNullOrWhiteSpace(GeoLatitude) && !string.IsNullOrWhiteSpace(GeoLongitude); }
+            get { return GeoLatitude.HasValue && GeoLongitude.HasValue; }
         }
 
         #endregion

--- a/Shared/Shared/Core/PropertyLocation.cs
+++ b/Shared/Shared/Core/PropertyLocation.cs
@@ -25,12 +25,6 @@ namespace AlarmWorkflow.Shared.Core
     [Serializable()]
     public sealed class PropertyLocation : IEquatable<PropertyLocation>
     {
-        #region Fields
-
-        private NumberFormatInfo _nfi = new NumberFormatInfo { NumberDecimalSeparator = "." };
-
-        #endregion
-
         #region Properties
 
         /// <summary>
@@ -70,14 +64,14 @@ namespace AlarmWorkflow.Shared.Core
         /// </summary>
         public string GeoLatitudeString
         {
-            get { return GeoLatitude.HasValue ? GeoLatitude.Value.ToString(_nfi) : string.Empty; }
+            get { return GeoLatitude.HasValue ? GeoLatitude.Value.ToString(CultureInfo.InvariantCulture) : string.Empty; }
         }
         /// <summary>
         ///  Gets the longitude of the location in a string with a "."
         /// </summary>
         public string GeoLongitudeString
         {
-            get { return GeoLongitude.HasValue ? GeoLongitude.Value.ToString(_nfi) : string.Empty; }
+            get { return GeoLongitude.HasValue ? GeoLongitude.Value.ToString(CultureInfo.InvariantCulture) : string.Empty; }
         }
         /// <summary>
         /// Gets/sets the name of the property (company, site, house etc.).
@@ -102,8 +96,8 @@ namespace AlarmWorkflow.Shared.Core
                     latlng = value.Split(';');
                 }
 
-                GeoLatitude = Convert.ToDouble(latlng[0], _nfi);
-                GeoLongitude = Convert.ToDouble(latlng[1], _nfi);
+                GeoLatitude = Convert.ToDouble(latlng[0], CultureInfo.InvariantCulture);
+                GeoLongitude = Convert.ToDouble(latlng[1], CultureInfo.InvariantCulture);
             }
         }
 

--- a/WindowsUIWidgets/GoogleMaps/GoogleMapsWidget.xaml.cs
+++ b/WindowsUIWidgets/GoogleMaps/GoogleMapsWidget.xaml.cs
@@ -174,7 +174,7 @@ namespace AlarmWorkflow.Windows.UIWidgets.GoogleMaps
                 String variables =
                     "directionsDisplay = new google.maps.DirectionsRenderer();" +
                     "var zoomOnAddress = false;" +
-                    "var dest = new google.maps.LatLng(" + _operation.Einsatzort.GeoLatitude + "," + _operation.Einsatzort.GeoLongitude + ");" +
+                    "var dest = new google.maps.LatLng(" + _operation.Einsatzort.GeoLatitudeString + "," + _operation.Einsatzort.GeoLongitudeString + ");" +
                     "var address = '" + _operation.Einsatzort.Street + " " + _operation.Einsatzort.StreetNumber + " " +
                     _operation.Einsatzort.ZipCode + " " + _operation.Einsatzort.City + "';" +
                     "var Home = '" + _configuration.Home + "';" +

--- a/WindowsUIWidgets/OSM/OSMWidget.xaml.cs
+++ b/WindowsUIWidgets/OSM/OSMWidget.xaml.cs
@@ -98,7 +98,7 @@ namespace AlarmWorkflow.Windows.UIWidgets.OSM
                 {
                     return "<h2>Konnte Geocodes fuer Zielort nicht bestimmen! Ggf. ist der Geocoding Job nicht aktiv?</h2>";
                 }
-                html = Properties.Resources.HTMLTemplate.Replace("{0}", _operation.Einsatzort.GeoLatitude).Replace("{1}", _operation.Einsatzort.GeoLongitude);
+                html = Properties.Resources.HTMLTemplate.Replace("{0}", _operation.Einsatzort.GeoLongitudeString).Replace("{1}", _operation.Einsatzort.GeoLongitudeString);
             }
             else
             {


### PR DESCRIPTION
Hi,
es gibt immer mehr ILSen die Koordinaten aufs Fax packen. Um Probleme mit "," und "." zu verhinden würde ich vorschlagen, dass wir intern das in ein double packen und einen Zugriff auf ein String mit "." anbieten (wird i.d.R. von Google, OSM,... gebraucht)
LG und schöne Weihnachten :christmas_tree: 