### PR TITLE
Set tesseract environment variable

### DIFF
--- a/AlarmSources/Fax/OcrSoftware/TesseractOcrSoftware.cs
+++ b/AlarmSources/Fax/OcrSoftware/TesseractOcrSoftware.cs
@@ -16,21 +16,33 @@
 using System.IO;
 using AlarmWorkflow.AlarmSource.Fax.Extensibility;
 using AlarmWorkflow.Shared.Core;
+using System;
 
 namespace AlarmWorkflow.AlarmSource.Fax.OcrSoftware
 {
     class TesseractOcrSoftware : IOcrSoftware
     {
+        #region Constants
+
+        private const string EnvTessdata = "TESSDATA_PREFIX";
+        
+        #endregion
+
         #region IOcrSoftware Members
 
         string[] IOcrSoftware.ProcessImage(OcrProcessOptions options)
         {
             using (ProcessWrapper proc = new ProcessWrapper())
             {
+                string tesseractPath = Path.Combine(Utilities.GetWorkingDirectory(), "tesseract");
+                string tessdataPath = Path.Combine(tesseractPath, "tessdata");
+
+                Environment.SetEnvironmentVariable(EnvTessdata, tessdataPath);
+
                 // If there is no custom directory
                 if (string.IsNullOrEmpty(options.SoftwarePath))
                 {
-                    proc.WorkingDirectory = Path.Combine(Utilities.GetWorkingDirectory(), "tesseract");
+                    proc.WorkingDirectory = tesseractPath;
                 }
                 else
                 {


### PR DESCRIPTION
Ein kleiner Fix für #139. Es setzt die Environment-Variable "TESSDATA_PREFIX" auf das AlarmWorkflow Verzeichnis. Dadurch wird die angepasste Sprachdatei des Projektes von jeder installierten Tesseract Version benutzt.