### PR TITLE
Improve fax thread stability & exception interval logger

### DIFF
--- a/AlarmSources/Fax/Properties/Resources.Designer.cs
+++ b/AlarmSources/Fax/Properties/Resources.Designer.cs
@@ -142,6 +142,16 @@ namespace AlarmWorkflow.AlarmSource.Fax.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to access fax source directory &apos;{0}&apos;
+        ///{1}.
+        /// </summary>
+        internal static string FaxDirAccessError {
+            get {
+                return ResourceManager.GetString("FaxDirAccessError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Ghostscript convert &apos;{0}&apos; to tiff.
         /// </summary>
         internal static string GhostscriptConvert {

--- a/AlarmSources/Fax/Properties/Resources.resx
+++ b/AlarmSources/Fax/Properties/Resources.resx
@@ -201,4 +201,8 @@
   <data name="GhostscriptConvertError" xml:space="preserve">
     <value>Error using Ghostscript. Maybe it's not installed.</value>
   </data>
+  <data name="FaxDirAccessError" xml:space="preserve">
+    <value>Unable to access fax source directory '{0}'
+{1}</value>
+  </data>
 </root>

--- a/Shared/Shared/Diagnostics/ExceptionIntervallLogger.cs
+++ b/Shared/Shared/Diagnostics/ExceptionIntervallLogger.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AlarmWorkflow.Shared.Diagnostics
+{
+    /// <summary>
+    /// Writes Exception Loggs at a predetermined interval.
+    /// </summary>
+    public class ExceptionIntervalLogger
+    {
+        #region Constructors
+
+        /// <summary>
+        /// Initializes the Exception Logger.
+        /// </summary>
+        /// <param name="logInterval">the interval how often a Exception should be logged</param>
+        public ExceptionIntervalLogger(TimeSpan logInterval)
+        {
+            _logInterval = logInterval;
+            _exceptionEntries = new List<TimedException>();
+        }
+
+        #endregion
+
+        #region Private Sublclasses
+
+        private class TimedException
+        {
+            public TimedException(Exception exception)
+            {
+                Exception = exception;
+                LastLogTime = DateTime.UtcNow;
+            }
+
+            public Exception Exception { get; }
+            public DateTime LastLogTime { get; set; }
+        }
+
+        #endregion
+
+        #region Fields
+
+        private readonly List<TimedException> _exceptionEntries;
+        private readonly TimeSpan _logInterval;
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Log a exception. The Logger decides to log or discard the exception.
+        /// </summary>
+        /// <param name="source">The component from which this type comes. The type name of the instance is used.</param>
+        /// <param name="ex">The exception.</param>
+        public void LogException(object source, Exception ex)
+        {
+            if (ShouldLogException(ex))
+            {
+                Logger.Instance.LogException(source, ex);
+            }
+        }
+
+        private bool ShouldLogException(Exception ex)
+        {
+            if (_exceptionEntries.Any(e => e.Exception.StackTrace == ex.StackTrace) &&
+                _exceptionEntries.Any(e => e.Exception.Message == ex.Message))
+            {
+                var exception = _exceptionEntries.Single(e => e.Exception.StackTrace == ex.StackTrace && e.Exception.Message == ex.Message);
+                if (exception.LastLogTime.Add(_logInterval) > DateTime.UtcNow) return false;
+                exception.LastLogTime = DateTime.UtcNow;
+            }
+            else
+            {
+                _exceptionEntries.Add(new TimedException(ex));
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Ability to log the exception as formatted text.
+        /// </summary>
+        /// <param name="ex">The exception.</param>
+        /// <param name="type">The message type.</param>
+        /// <param name="source">The component from which this type comes. The type name of the instance is used.</param>
+        /// <param name="format">The text to use as the format string.</param>
+        /// <param name="arguments">The arguments to use for the format string.</param>
+        public void LogFormat(Exception ex, LogType type, object source, string format, params object[] arguments)
+        {
+            if (ShouldLogException(ex))
+            {
+                Logger.Instance.LogFormat(type, source, format, arguments);
+            }
+        }
+
+        /// <summary>
+        /// Reset the stored exception entries.
+        /// </summary>
+        public void ResetExceptionCollection()
+        {
+            _exceptionEntries.Clear();
+        }
+
+        #endregion
+    }
+}

--- a/Shared/Shared/Shared.csproj
+++ b/Shared/Shared/Shared.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Core\AlarmWorkflowPackageAttribute.cs" />
     <Compile Include="Core\IProxyType.cs" />
     <Compile Include="Core\OptionStringHelper.cs" />
+    <Compile Include="Diagnostics\ExceptionIntervallLogger.cs" />
     <Compile Include="Diagnostics\Reports\ExceptionDetail.cs" />
     <Compile Include="Extensibility\IParser.cs" />
     <Compile Include="ObjectExpressions\CustomScriptExecutionException.cs" />


### PR DESCRIPTION
A Bugfix to improve the stability while searching for new faxes.
To achieve this a new logger extension was necessary. The logger
extension prevents the log files from overflow.

Fix issue #147 