### PR TITLE
Set tesseract environment variable

### DIFF
--- a/AlarmSources/Fax/OcrSoftware/TesseractOcrSoftware.cs
+++ b/AlarmSources/Fax/OcrSoftware/TesseractOcrSoftware.cs
@@ -16,21 +16,44 @@
 using System.IO;
 using AlarmWorkflow.AlarmSource.Fax.Extensibility;
 using AlarmWorkflow.Shared.Core;
+using System;
+using AlarmWorkflow.Shared.Diagnostics;
 
 namespace AlarmWorkflow.AlarmSource.Fax.OcrSoftware
 {
     class TesseractOcrSoftware : IOcrSoftware
     {
+
+        #region Constants
+
+        private const string EnvTessdata = "TESSDATA_PREFIX";
+
+        #endregion
+
         #region IOcrSoftware Members
 
         string[] IOcrSoftware.ProcessImage(OcrProcessOptions options)
         {
             using (ProcessWrapper proc = new ProcessWrapper())
             {
+                string tesseractPath = Path.Combine(Utilities.GetWorkingDirectory(), "tesseract");
+                string tessdataPath = Path.Combine(tesseractPath, "tessdata");
+
+                try
+                {
+                    Environment.SetEnvironmentVariable(EnvTessdata, tessdataPath);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Instance.LogFormat(LogType.Error, this, Properties.Resources.OcrSoftwareTesseractError);
+                    Logger.Instance.LogException(this, ex);
+                }
+                
+                
                 // If there is no custom directory
                 if (string.IsNullOrEmpty(options.SoftwarePath))
                 {
-                    proc.WorkingDirectory = Path.Combine(Utilities.GetWorkingDirectory(), "tesseract");
+                    proc.WorkingDirectory = tesseractPath;
                 }
                 else
                 {

--- a/AlarmSources/Fax/Properties/Resources.Designer.cs
+++ b/AlarmSources/Fax/Properties/Resources.Designer.cs
@@ -233,6 +233,15 @@ namespace AlarmWorkflow.AlarmSource.Fax.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error set tesseract environment variable: {0}.
+        /// </summary>
+        internal static string OcrSoftwareTesseractError {
+            get {
+                return ResourceManager.GetString("OcrSoftwareTesseractError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Operation parsed in &apos;{0}&apos; milliseconds..
         /// </summary>
         internal static string ParsingOperationCompleted {

--- a/AlarmSources/Fax/Properties/Resources.resx
+++ b/AlarmSources/Fax/Properties/Resources.resx
@@ -205,4 +205,7 @@
     <value>Unable to access fax source directory '{0}'
 {1}</value>
   </data>
+  <data name="OcrSoftwareTesseractError" xml:space="preserve">
+    <value>Error set tesseract environment variable: {0}</value>
+  </data>
 </root>

--- a/Resources/Documentation/RelNotes/1.0.2.0.txt
+++ b/Resources/Documentation/RelNotes/1.0.2.0.txt
@@ -13,6 +13,7 @@ Generelles
   * Korrekturwörterbuch für E-Mail Alarmquelle
   * Optimierungen bei Druckerauswahl
   * Möglichkeit zur Selektion von bereits auf dem System installierten Druckern
+  * Setzen der Environment-Variable "TESSDATA_PREFIX" auf das AlarmWorkflow Verzeichnis (Sprachdatei des Projektes wird allen Tesseract Versionen verwendet).
 
 Gelöste Probleme
 ----------------


### PR DESCRIPTION
Ein kleiner (verbesserter) Fix für #139. Es setzt die Environment-Variable "TESSDATA_PREFIX" auf das AlarmWorkflow Verzeichnis. Dadurch wird die angepasste Sprachdatei des Projektes von jeder installierten Tesseract Version benutzt.